### PR TITLE
SMRE-595: Add action to install csvkit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,14 +17,24 @@ permissions:
   contents: read
 
 jobs:
-  bats:
+  install-csvkit:
+    # Ideally this would be tested on a self-hosted runner,
+    # but that's not available in this case.
     runs-on: "ubuntu-latest"
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Install csvkit
+        uses: ./install-csvkit/
+      - name: Verify PATH
         run: |
-          python -m pip install --upgrade pip
-          pip install csvkit
+          csvcut --version
+
+  bats:
+    runs-on: "ubuntu-latest"
+    needs: [install-csvkit]
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: ./install-csvkit/
       - name: Install Bats and bats libs
         id: setup-bats
         uses: bats-core/bats-action@42fcc8700f773c075a16a90eb11674c0318ad507 # v3.0.1
@@ -41,13 +51,10 @@ jobs:
 
   test-collect:
     runs-on: "ubuntu-latest"
+    needs: [install-csvkit]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-      - name: Install csvkit
-        run: |
-          python -m pip install --upgrade pip
-          pip install csvkit
+      - uses: ./install-csvkit/
 
       - name: Test Collection
         id: collect

--- a/install-csvkit/action.yml
+++ b/install-csvkit/action.yml
@@ -1,0 +1,17 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: MPL-2.0
+
+name: "PAO Install CSVKit"
+author: "HashiCorp"
+description: "Install the csvkit tools used by actions-pao-tool"
+
+branding:
+  color: "blue"
+  icon: "package"
+
+runs:
+  using: composite
+  steps:
+    - name: Install csvcut
+      shell: bash
+      run: "${GITHUB_ACTION_PATH}/../scripts/install-csvkit"

--- a/rename-by-part-number/action.yml
+++ b/rename-by-part-number/action.yml
@@ -40,10 +40,7 @@ runs:
   steps:
     - name: Install csvkit
       shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        pip install csvkit 
-    - name: 
+      run: "${GITHUB_ACTION_PATH}/../scripts/install-csvkit"
     - name: Rename files by part number
       shell: bash
       env:

--- a/scripts/install-csvkit
+++ b/scripts/install-csvkit
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+main() {
+    # no-op if already installed
+    if csvcut --version 2>/dev/null ; then
+        exit 0
+    fi
+
+    sudo apt update
+    sudo apt install -y python3 python3-pip </dev/null
+
+    param=
+    if pip install --help |& grep break-system-packages >/dev/null ; then
+        param='--break-system-packages'
+    fi
+    pip install $param csvkit
+
+    # hint at what we got
+    export PATH="$HOME/.local/bin:$PATH"
+    echo "PATH=$PATH" >> "$GITHUB_ENV"
+    csvcut --version
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main "$@"
+fi
+
+#  vim: set ts=4 sw=4 tw=0 et :

--- a/verify-required-files/action.yml
+++ b/verify-required-files/action.yml
@@ -28,9 +28,7 @@ runs:
   steps:
     - name: Install csvkit
       shell: bash
-      run: |
-        python -m pip install --upgrade pip
-        pip install csvkit
+      run: "${GITHUB_ACTION_PATH}/../scripts/install-csvkit"
     - name: Validate required files
       shell: bash
       # Validate the products to require without requiring all products to have multiple SKUs


### PR DESCRIPTION
This collects the steps for installing csvkit into a reusable action.

The required steps differ between GH-hosted and self-hosted runners, so this action must support both, although it cannot be directly tested on self-hosted runners due to being in a public repository.

This HEAD (79c356a) was used in this [prepare run](https://github.com/HashiCorp-RelEng-Dev/crt-workflows-common/actions/runs/16425254049/job/46413918890#step:7:1).