### PR TITLE
Fail over-length translations

### DIFF
--- a/scripts/translate-artifact-name.sh
+++ b/scripts/translate-artifact-name.sh
@@ -26,8 +26,8 @@ xlate() {
     repl="${repl/crt-core-}" # strip crt-core- prefix for testing with helloworld
     repl="${repl/_production_/_}" # TFE puts 'production' in tarball names -- remove to shorten the name
     repl="${repl/-enterprise}" # consul-enterprise -> consul
-    repl="${repl/_release_/_}" # nomad docker images have 'release' in their names
-    repl="${repl/_default[-_]/_}" # consul and vault docker images have 'default' in their names
+    repl="${repl/[-_]release[-_]/_}" # nomad docker images have 'release' in their names
+    repl="${repl/[-_]default[-_]/_}" # consul and vault docker images have 'default' in their names
     repl="${repl/[-_]fips[-_]/_}" # fips word is redundant
     repl="${repl/docker.}" # remove 'docker', it's redundant with '.tar'
     repl="${repl/redhat.}" # remove 'redhat', it's irrelevant for PAO

--- a/scripts/translate-artifact-name.sh
+++ b/scripts/translate-artifact-name.sh
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+# MAX_LENGTH is the maximum length of the file name allowed by Tequila, including any extension.
+# Over-length names yield errors.
+readonly MAX_LENGTH=40
+
 xlate() {
     local name="$1" repl=""
     repl="$name"
@@ -75,6 +81,11 @@ xlate() {
             repl="${repl/_F3-/-}"
             ;;
     esac
+
+    if [ "${#repl}" -gt 40 ]; then
+        echo "${repl}: translated name is ${#repl} characters, maximum allowed is ${MAX_LENGTH}." 1>&2
+        return 1
+    fi
 
     echo "$repl"
 }

--- a/tests/translate-artifact-name.bats
+++ b/tests/translate-artifact-name.bats
@@ -8,8 +8,6 @@ bats_require_minimum_version 1.7.0
 # This must be in the current shell, so it cannot be within a bats setup* function.
 eval "$(echo -n 'bats_run()' ; declare -f run | tail -n +2)"
 
-readonly MAX_LENGTH=40
-
 setup() {
     bats_load_library bats-support
     bats_load_library bats-assert
@@ -30,21 +28,15 @@ assert_string_absent() {
 @test "all products translation" {
     local product
     for product in "${ALL_PRODUCTS[@]}" ; do
-        output="$(xlate "$product")"
+        unset output
+        bats_run -- xlate "$product"
         #echo "xlate: [$product] -> [$output]" 1>&3
-        echo "$output" 1>&3
+
         assert_string_absent "terraform-enterprise" "$output"
         assert_string_absent "fips" "$output"
         assert_string_absent "hsm" "$output"
         assert_string_absent "+ent" "$output"
-    done
-}
-
-@test "all products length" {
-    local product
-    for product in "${ALL_PRODUCTS[@]}" ; do
-        output="$(xlate "$product")"
-        assert [ "${#output}" -le $MAX_LENGTH ]
+        assert_success
     done
 }
 

--- a/tests/translate-artifact-name.bats
+++ b/tests/translate-artifact-name.bats
@@ -36,6 +36,10 @@ assert_string_absent() {
         assert_string_absent "fips" "$output"
         assert_string_absent "hsm" "$output"
         assert_string_absent "+ent" "$output"
+        assert_string_absent "_-" "$output"
+        assert_string_absent "-_" "$output"
+        assert_string_absent "--" "$output"
+        assert_string_absent "__" "$output"
         assert_success
     done
 }

--- a/tests/translate-artifact-name.bats
+++ b/tests/translate-artifact-name.bats
@@ -25,6 +25,14 @@ assert_string_absent() {
 }
 
 # bats test_tags=group:translation
+@test "over-length name" {
+    local name="product-name-that-is-longer-than-40-characters_0.0.1_linux_amd64.zip"
+    bats_run -- xlate "$name"
+    assert_line --partial "maximum allowed is"
+    assert_failure
+}
+
+# bats test_tags=group:translation
 @test "all products translation" {
     local product
     for product in "${ALL_PRODUCTS[@]}" ; do

--- a/tests/translate-artifact-name.bats
+++ b/tests/translate-artifact-name.bats
@@ -152,6 +152,7 @@ ALL_PRODUCTS=(
     "crt-core-helloworld-enterprise-1.0.0+ent.fips1402-1.x86_64.rpm"
     "crt-core-helloworld-enterprise-1.0.0+ent.fips1403-1.x86_64.rpm"
     "crt-core-helloworld-enterprise-1.0.0+ent.fips1403-1.aarch64.rpm"
+    "crt-core-helloworld-enterprise_release-default_linux_arm64_1.0.0+ent_df551a2887ee92c6e3c7a677559cb181ba480c03.docker.dev.tar"
     "nomad-enterprise-1.9.6+ent-1.aarch64.rpm"
     "nomad-enterprise-1.9.6+ent-1.s390x.rpm"
     "nomad-enterprise-1.9.6+ent-1.x86_64.rpm"


### PR DESCRIPTION
The artifact name translator now fails if the resulting name is too long for PAO.