### PR TITLE
Adds exception for .sig files to xlate script, with test

### DIFF
--- a/scripts/translate-artifact-name.sh
+++ b/scripts/translate-artifact-name.sh
@@ -82,7 +82,8 @@ xlate() {
             ;;
     esac
 
-    if [ "${#repl}" -gt 40 ]; then
+    # .sig files are allowed to exceed MAX_LENGTH because they are not uploaded to PAO
+    if [[ ! "$repl" =~ \.(sig)$ ]] && [ "${#repl}" -gt $MAX_LENGTH ]; then
         echo "${repl}: translated name is ${#repl} characters, maximum allowed is ${MAX_LENGTH}." 1>&2
         return 1
     fi

--- a/tests/translate-artifact-name.bats
+++ b/tests/translate-artifact-name.bats
@@ -264,4 +264,5 @@ ALL_PRODUCTS=(
     "vault_1.19.5+ent.fips1403_linux_arm64.zip"
     "vault_1.19.5+ent.hsm.fips1403_linux_amd64.zip"
     "vault_1.19.5+ent.hsm.fips1403_linux_arm64.zip"
+    "crt-core-helloworld_1.0.0+ent.fips1403_SHA256SUMS.72D7468F.sig"
 )


### PR DESCRIPTION
We may occasionally see .sig files in build artifacts, but they should not block the pipeline if the translated names are too long until we are actually using them. 

This small change ensures that long .sig filenames won't fail validation from translate-artifact-name.sh and block the staging promotion.