### PR TITLE
Remove redundant -hsm in UBI image names

### DIFF
--- a/scripts/translate-artifact-name.sh
+++ b/scripts/translate-artifact-name.sh
@@ -12,6 +12,7 @@ xlate() {
 
     # transformations
     repl="${repl/+ent}"
+    repl="${repl/ubi-hsm/ubi}" # -hsm in docker image name is redundant
     repl="${repl/.hsm/_H}" # separator included here because hsm is consistently placed before FIPS; but this is brittle
     repl="${repl/.fips1402/_F2}"
     repl="${repl/H_F2/HF2}" # for hsm+fips remove the separator between them

--- a/tests/translate-artifact-name.bats
+++ b/tests/translate-artifact-name.bats
@@ -48,6 +48,7 @@ assert_string_absent() {
         assert_string_absent "-_" "$output"
         assert_string_absent "--" "$output"
         assert_string_absent "__" "$output"
+        assert_string_absent "ubi-H_" "$output"
         assert_success
     done
 }
@@ -265,4 +266,6 @@ ALL_PRODUCTS=(
     "vault_1.19.5+ent.hsm.fips1403_linux_amd64.zip"
     "vault_1.19.5+ent.hsm.fips1403_linux_arm64.zip"
     "crt-core-helloworld_1.0.0+ent.fips1403_SHA256SUMS.72D7468F.sig"
+    "vault-enterprise_ubi-hsm-fips_linux_arm64_1.21.0+ent.hsm.fips1403_9c6cecbb7bb5b44fd543a06c248cfa06b824b7d5.docker.tar"
+    "vault-enterprise_ubi-hsm_linux_amd64_1.21.0+ent.hsm_9c6cecbb7bb5b44fd543a06c248cfa06b824b7d5.docker.tar"
 )


### PR DESCRIPTION
The version string also includes hsm, which is translated to H in short names, so it's not needed in the build target name.