### PR TITLE
Update actions/upload-artifact version

### DIFF
--- a/.changes/unreleased/Changed-20260513-123343.yaml
+++ b/.changes/unreleased/Changed-20260513-123343.yaml
@@ -1,0 +1,3 @@
+kind: Changed
+body: Updated actions/upload-artifact version that supports NodeJS 24+
+time: 2026-05-13T12:33:43.740706-07:00

--- a/collect/action.yml
+++ b/collect/action.yml
@@ -28,7 +28,7 @@ runs:
         "${GITHUB_ACTION_PATH}/../scripts/collect-meta-artifacts" "$tmpdir" "${{ env.PAO_META }}"
         unzip -l "${tmpdir}/${PAO_META}"
         echo "archive=${tmpdir}/${PAO_META}" | tee -a "$GITHUB_OUTPUT"
-    - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       env:
         PAO_META: crt-pao-meta.zip
       with:


### PR DESCRIPTION
New version uses NodeJS 24 as 20 is deprecated